### PR TITLE
Tentative 0.0.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,6 +329,8 @@ export class WACZ {
 
     const info = verbose ? this.log.info : () => {}
 
+    info(`${this.WARCs.length} WARC(s) to process.`)
+
     info(`Initializing output stream at: ${this.output}`)
     this.initOutputStreams()
 
@@ -473,7 +475,7 @@ export class WACZ {
           upperBound = cdxArray.length - 1
         }
 
-        cdxSlice = cdxArray.slice(i, upperBound).join('')
+        cdxSlice = cdxArray.slice(i, upperBound + 1).join('')
 
         // Deflate said slice
         cdxSliceGzipped = this.gzip(cdxSlice)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lil/js-wacz",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lil/js-wacz",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lil/js-wacz",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "JavaScript module and CLI tool for working with web archive data using the WACZ format specification.",
   "main": "index.js",
   "type": "module",

--- a/workers/indexWARC.js
+++ b/workers/indexWARC.js
@@ -15,6 +15,12 @@ import { v4 as uuidv4 } from 'uuid'
  *
  * Worker function.
  *
+ * [!] Feb 28 2023:
+ * This is a temporary and much less efficient implementation of this worker.
+ * In order to circumvent a _potential_ bug in WARCParser.iterRecords(),
+ * WARCs are iterated over twice at the moment.
+ * TBD.
+ *
  * @param {Object} options
  * @param {string} options.filename
  * @param {boolean} [options.detectPages=true]
@@ -24,62 +30,78 @@ import { v4 as uuidv4 } from 'uuid'
 export default async (options = {}) => {
   const filename = options?.filename
   const detectPages = options?.detectPages !== false
+  const cdx = []
+  const pages = []
 
   if (!filename) {
     throw new Error('No filename provided.')
   }
 
-  await fs.access(filename)
+  await fs.access(filename) // throws if file does not exist / is not accessible
 
+  // Try to build CDX for current warc
+  cdx.push(...await getCDX(filename))
+
+  // Try to detect pages in record
+  if (detectPages) {
+    pages.push(...await getPages(filename))
+  }
+
+  return { cdx, pages }
+}
+
+/**
+ * Iterates over a WARC file and generates CDXJ entries, which will be added to the main `cdx` array.
+ * @param {string} filename - Path to .warc or .warc.gz file
+ * @returns {Promise<string[]>} - CDXJ entries
+ */
+const getCDX = async (filename) => {
   const cdx = []
-  const pages = []
   const stream = createReadStream(filename)
-  const parser = new WARCParser(stream)
   const indexer = new CDXIndexer()
 
-  for await (const record of parser) {
-    // Skip records that should not be indexed
-    if (!indexer.filterRecord(record)) {
+  for await (const record of indexer.iterIndex([{ reader: stream, filename: basename(filename) }])) {
+    if (record.mime === 'application/warc-fields') {
       continue
     }
 
-    // Records need to be read fully so:
-    // - `indexer.indexRecord()` knows their actual content-length
-    // - The pages detection mechanism can access their content.
-    await record.readFully()
+    cdx.push(indexer.serializeCDXJ(record))
+  }
 
-    //
-    // Create CDX entry for current record
-    //
-    const entry = indexer.indexRecord(record, parser, basename(filename))
+  return cdx
+}
 
-    if (entry && entry?.mime !== 'application/warc-fields') {
-      cdx.push(indexer.serializeCDXJ(entry))
+/**
+ * Iterates over a WARC file and tries to detect HTML pages, so they can be later added to pages.jsonl.
+ * @param {string} filename - Path to .warc or .warc.gz file
+ * @returns {Promise<WACZPage[]>}
+ */
+const getPages = async (filename) => {
+  const pages = []
+  const stream = createReadStream(filename)
+  const parser = new WARCParser(stream)
+
+  for await (const record of parser) {
+    const warcType = record.warcHeader('WARC-Type')
+    const statusCode = record?.httpHeaders?.statusCode
+    const contentType = record?.httpHeaders?.headers?.get('content-type')
+    const targetURI = record.warcHeader('WARC-Target-URI')
+    const warcDate = record.warcHeader('WARC-Date')
+
+    // Eligible candidates: text/html response with success status code, target URI and date
+    if (
+      warcType !== 'response' ||
+      statusCode > 299 ||
+      !contentType ||
+      !contentType.startsWith('text/html') ||
+      !targetURI ||
+      !warcDate
+    ) {
+      continue
     }
 
-    //
-    // Try to detect pages in record
-    //
-    if (detectPages) {
-      const warcType = record.warcHeader('WARC-Type')
-      const statusCode = record?.httpHeaders?.statusCode
-      const contentType = record?.httpHeaders?.headers?.get('content-type')
-      const targetURI = record.warcHeader('WARC-Target-URI')
-      const warcDate = record.warcHeader('WARC-Date')
-
-      // Eligible candidates: text/html response with success status code, target URI and date
-      if (
-        warcType !== 'response' ||
-        statusCode > 299 ||
-        !contentType ||
-        !contentType.startsWith('text/html') ||
-        !targetURI ||
-        !warcDate
-      ) {
-        continue
-      }
-
-      // Access content body and try to find page title, if any.
+    // Access content body and try to find page title, if any.
+    try {
       const body = await record.contentText()
       const html = parseHTML(body)
       const title = html?.querySelector('title')?.textContent
@@ -90,8 +112,8 @@ export default async (options = {}) => {
         title: title || targetURI,
         ts: warcDate
       })
-    }
+    } catch (_err) { }
   }
 
-  return { cdx, pages }
+  return pages
 }


### PR DESCRIPTION
**Temporary:**
Split `indexWARC` process between indexing and pages detection to circumvent an issue discovered with the indexing of small WARCs when calling `CDXIndexer.indexRecord()` in a `WARCParser` iteration loop.

This change leads to degraded performance compared to 0.0.5.