### PR TITLE
Publish helper

### DIFF
--- a/.services/publish/README.md
+++ b/.services/publish/README.md
@@ -1,0 +1,1 @@
+This folder contains utility scripts for helping with the management of the `@harvard-lil/js-wacz` package.

--- a/.services/publish/run.sh
+++ b/.services/publish/run.sh
@@ -1,0 +1,45 @@
+# Step-by-step publish helper
+cd ../../;
+
+read -p "Run linter (y/n)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    if npm run lint ; then
+        echo "Lint OK"
+    else
+        echo "Lint step failed"
+    fi
+fi
+
+read -p "Run tests (y/n)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    if npm run test ; then
+        echo "Tests OK"
+    else
+        echo "Tests failed"
+    fi
+fi
+
+read -p "Bump version number (y/n)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    npm version patch --no-git-tag-version;
+fi
+
+read -p "Do a publish dry-run (y/n)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    npm publish --dry-run;
+fi
+
+read -p "⚠️ Publish on NPM (y/n)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    npm publish --access public;
+fi

--- a/README.md
+++ b/README.md
@@ -250,5 +250,25 @@ These are optional, and can be added to a local `.env` file which will be automa
 | `TEST_SIGNING_URL` | URL of an [authsign-compatible endpoint](https://github.com/webrecorder/authsign) for signing WACZ files. To run such an endpoint locally, use `npm run dev-signer` and set this variable to `http://127.0.0.1:5000/sign`; see [.services/signer](.services/signer).|
 | `TEST_SIGNING_TOKEN` | If required by the server at `TEST_SIGNING_URL`, an authentication token. |
 
+
+### Available CLI
+
+```bash
+# Runs test suite
+npm run test
+
+# Runs linter
+npm run lint
+
+# Runs linter and attempts to automatically fix issues
+npm run lint-autofix
+
+# Step-by-step NPM publishing helper
+npm run publish-util
+
+# Runs a local instance of wacz-signer for test purposes (see "Testing" section)
+npm run dev-signer
+```
+
 [👆 Back to summary](#summary)
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "standard",
     "lint-autofix": "standard --fix",
     "test": "node --test",
-    "dev-signer": "cd .services/signer; bash ./run.sh &"
+    "dev-signer": "cd .services/signer; bash ./run.sh &",
+    "publish-util": "cd .services/publish; bash ./run.sh"
   },
   "repository": {
     "type": "git",

--- a/test-and-publish.sh
+++ b/test-and-publish.sh
@@ -1,4 +1,0 @@
-npm run lint;
-npm run test;
-npm version patch --no-git-tag-version;
-npm publish --access public;


### PR DESCRIPTION
- Moves existing NPM publishing scripts to `.services`. This script was also update to be more "step by step".
- Docs update