### PR TITLE
Run signer from the top level; add notes about overwriting `.env`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Run signer
       run: |
+        echo 'TEST_SIGNING_URL=http://localhost:5000/sign' > .env
         cd .services/signer/
         bash ./run.sh &
         sleep 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,6 @@ jobs:
 
     - name: Run signer
       run: |
-        echo 'TEST_SIGNING_URL=http://localhost:5000/sign' > .env
         cd .services/signer/
         bash ./run.sh &
         sleep 5

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 tmp/
 tmp.js
 .env
-env
+.venv/
+env/
 *.pem
 __pycache__/

--- a/.services/signer/README.md
+++ b/.services/signer/README.md
@@ -1,12 +1,10 @@
 To test js-wacz against a locally-running signing service, install
 [mkcert](https://github.com/FiloSottile/mkcert). Then, in this
-directory, run 
+directory, run
 
 ```
 bash ./run.sh
 ```
 
-(An equivalent, from the top level of this repo, is `npm run
-dev-signer`.) You can then run `npm run test`, setting
-`TEST_SIGNING_URL=http://localhost:5000/sign` on the command line or
-in `.env`.
+(An equivalent is `npm run dev-signer`. Note that this will overwrite
+the top-level `.env`.)

--- a/.services/signer/run.sh
+++ b/.services/signer/run.sh
@@ -8,8 +8,8 @@ then
 fi
 
 # make and activate virtual environment
-python3 -m venv env
-source ./env/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 
 # install requirements
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ These are optional, and can be added to a local `.env` file which will be automa
 
 | Name | Description |
 | --- | --- |
-| `TEST_SIGNING_URL` | URL of an [authsign-compatible endpoint](https://github.com/webrecorder/authsign) for signing WACZ files. To run such an endpoint locally, use `npm run dev-signer` and set this variable to `http://127.0.0.1:5000/sign`; see [.services/signer](.services/signer).|
+| `TEST_SIGNING_URL` | URL of an [authsign-compatible endpoint](https://github.com/webrecorder/authsign) for signing WACZ files. To run such an endpoint locally, use `npm run dev-signer`, which will overwrite `.env` and set this variable to `http://localhost:5000/sign`; see [.services/signer](.services/signer).|
 | `TEST_SIGNING_TOKEN` | If required by the server at `TEST_SIGNING_URL`, an authentication token. |
 
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint": "standard",
     "lint-autofix": "standard --fix",
     "test": "node --test",
-    "dev-signer": "cd .services/signer; bash ./run.sh",
-    "publish-util": "cd .services/publish; bash ./run.sh"
+    "dev-signer": "echo 'TEST_SIGNING_URL=http://localhost:5000/sign' > .env ; cd .services/signer ; bash ./run.sh",
+    "publish-util": "cd .services/publish ; bash ./run.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This now sets up `.env` correctly for testing against the local signer.