### PR TITLE
Bump version of wacz_signing

### DIFF
--- a/.services/signer/requirements.txt
+++ b/.services/signer/requirements.txt
@@ -268,9 +268,9 @@ six==1.16.0 ; python_version >= "3.9" and python_version < "4.0" \
 urllib3==1.26.14 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72 \
     --hash=sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1
-wacz-signing==0.2.7 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:0281f695929244cc5636879d413d72fac42d3e1b3630eaab9eddc101c59b44b5 \
-    --hash=sha256:c1e39ab56c940b1150f56ab8bc426ab6cb1a38c1023568a1c37537f274c51f89
+wacz-signing==0.2.8 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:4b068fe02fc44ef87c23e1e8ae0ff415165fd8e0f69a9680c8eecf8097146c60 \
+    --hash=sha256:a09e280347641f369cac7bf79c27ad4117186b27a063b23b87f29ccf175a85f1
 werkzeug==2.2.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe \
     --hash=sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612


### PR DESCRIPTION
This is a very minor, almost no-op change, that brings the code's sense of its version back into sync with the package's version.