### PR TITLE
`indexWARC` worker: Combine Indexing and page detection steps

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,8 +7,8 @@ import log from 'loglevel'
 import logPrefix from 'loglevel-plugin-prefix'
 import { Command } from 'commander'
 
-import { WACZ } from './index.js'
-import { PACKAGE_INFO, LOGGING_COLORS } from './constants.js'
+import { WACZ } from '../index.js'
+import { PACKAGE_INFO, LOGGING_COLORS } from '../constants.js'
 
 const program = new Command()
 

--- a/bin/cli.test.js
+++ b/bin/cli.test.js
@@ -7,14 +7,14 @@ import StreamZip from 'node-stream-zip'
 
 import { execSync } from 'node:child_process'
 
-import { FIXTURES_PATH } from './constants.js'
+import { FIXTURES_PATH } from '../constants.js'
 
 // TODO: Actual tests CLI test suite.
 // For this very first version of this package, a decision was made to focus on tests of the underlying library.
 test('Invoke "create" command and check that a WACZ was created.', async (_t) => {
   const output = 'tmp.wacz'
 
-  let command = 'node cli create '
+  let command = 'node bin/cli create '
   command += `--file "${FIXTURES_PATH}${sep}*.warc.gz" `
   command += `--output ${output} `
 

--- a/cli.js
+++ b/cli.js
@@ -19,7 +19,7 @@ const program = new Command()
 program
   .name(PACKAGE_INFO.name)
   .description(PACKAGE_INFO.description)
-  .version(PACKAGE_INFO.version)
+  .version(PACKAGE_INFO.version, '-v, --version')
 
 /**
  * `create` command

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ export class WACZ {
           typeof this.log.warn !== 'function' ||
           typeof this.log.error !== 'function'
       ) {
-        throw new Error('"logger" must be compatible with the Console API.')
+        throw new Error('"log" must be compatible with the Console API.')
       }
     }
 
@@ -329,42 +329,42 @@ export class WACZ {
 
     const info = verbose ? this.log.info : () => {}
 
-    info(`${this.WARCs.length} WARC(s) to process.`)
+    info(`${this.WARCs.length} WARC(s) to process`)
 
     info(`Initializing output stream at: ${this.output}`)
     this.initOutputStreams()
 
-    info('Initializing indexer.')
+    info('Initializing indexer')
     this.initWorkerPool()
 
-    info('Indexing WARCS.')
+    info('Indexing WARCS')
     await this.indexWARCs()
 
-    info('Harvesting sorted indexes from trees.')
+    info('Harvesting sorted indexes from trees')
     this.harvestArraysFromTrees()
 
-    info('Writing CDX to WACZ.')
+    info('Writing CDX to WACZ')
     await this.writeIndexesToZip()
 
-    info('Writing pages.jsonl to WACZ.')
+    info('Writing pages.jsonl to WACZ')
     await this.writePagesToZip()
 
-    info('Writing WARCs to WACZ.')
+    info('Writing WARCs to WACZ')
     await this.writeWARCsToZip()
 
-    info('Writing datapackage.json to WACZ.')
+    info('Writing datapackage.json to WACZ')
     await this.writeDatapackageToZip()
 
-    info('Writing datapackage-digest.json to WACZ.')
+    info('Writing datapackage-digest.json to WACZ')
     if (this.signingUrl) {
       info(`(Will request signature from: ${this.signingUrl})`)
     }
     await this.writeDatapackageDigestToZip()
 
-    info('Finalizing WACZ.')
+    info('Finalizing WACZ')
     await this.finalize()
 
-    info('Done.')
+    info('WACZ was finalized')
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "piscina": "^3.2.0",
         "sorted-btree": "^1.8.1",
         "uuid": "^9.0.0",
-        "warcio": "github:webrecorder/warcio.js#add-cdx-record-indexer"
+        "warcio": "github:matteocargnelutti/warcio.js#cdxindexer-filter-metadata"
       },
       "bin": {
         "js-wacz": "cli.js"
@@ -3521,7 +3521,7 @@
     },
     "node_modules/warcio": {
       "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/webrecorder/warcio.js.git#85fa47829046f5e1707fa2f9956cbd61cc7ab94e",
+      "resolved": "git+ssh://git@github.com/matteocargnelutti/warcio.js.git#67f2b944f8f8484a23e7497bf2ee76d832e8d43b",
       "license": "Apache-2.0",
       "dependencies": {
         "base32-encode": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
         "piscina": "^3.2.0",
         "sorted-btree": "^1.8.1",
         "uuid": "^9.0.0",
-        "warcio": "github:matteocargnelutti/warcio.js#cdxindexer-filter-metadata"
+        "warcio": "^2.1.0"
       },
       "bin": {
-        "js-wacz": "cli.js"
+        "js-wacz": "bin/cli.js"
       },
       "devDependencies": {
         "dotenv": "^16.0.3",
@@ -3521,8 +3521,8 @@
     },
     "node_modules/warcio": {
       "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/matteocargnelutti/warcio.js.git#67f2b944f8f8484a23e7497bf2ee76d832e8d43b",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/warcio/-/warcio-2.1.0.tgz",
+      "integrity": "sha512-NQPvYkNZhZOqcFhAHn2iuFhEQmiUv+mE1KI8BD+J3emgkdNGRv3P1o+gBCE6Nxnzk7bEkBreoAjhZ4osl+Ps1Q==",
       "dependencies": {
         "base32-encode": "^2.0.0",
         "pako": "^1.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "piscina": "^3.2.0",
         "sorted-btree": "^1.8.1",
         "uuid": "^9.0.0",
-        "warcio": "^2.0.1"
+        "warcio": "github:webrecorder/warcio.js#add-cdx-record-indexer"
       },
       "bin": {
         "js-wacz": "cli.js"
@@ -3520,9 +3520,9 @@
       "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "node_modules/warcio": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/warcio/-/warcio-2.0.1.tgz",
-      "integrity": "sha512-+1AyOQJ3hjLkZwT0mIn2xGrg+RRbyu+fWXuCpU1A/VG25bVzrcsvj8T0lWToylJU4Xf9Q8W57Jej/iUxGxaHKg==",
+      "version": "2.1.0",
+      "resolved": "git+ssh://git@github.com/webrecorder/warcio.js.git#85fa47829046f5e1707fa2f9956cbd61cc7ab94e",
+      "license": "Apache-2.0",
       "dependencies": {
         "base32-encode": "^2.0.0",
         "pako": "^1.0.11",
@@ -3646,9 +3646,9 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "piscina": "^3.2.0",
     "sorted-btree": "^1.8.1",
     "uuid": "^9.0.0",
-    "warcio": "github:matteocargnelutti/warcio.js#cdxindexer-filter-metadata"
+    "warcio": "^2.1.0"
   },
   "devDependencies": {
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "piscina": "^3.2.0",
     "sorted-btree": "^1.8.1",
     "uuid": "^9.0.0",
-    "warcio": "^2.0.1"
+    "warcio": "github:webrecorder/warcio.js#add-cdx-record-indexer"
   },
   "devDependencies": {
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "piscina": "^3.2.0",
     "sorted-btree": "^1.8.1",
     "uuid": "^9.0.0",
-    "warcio": "github:webrecorder/warcio.js#add-cdx-record-indexer"
+    "warcio": "github:matteocargnelutti/warcio.js#cdxindexer-filter-metadata"
   },
   "devDependencies": {
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "bin": {
-    "js-wacz": "./cli.js"
+    "js-wacz": "./bin/cli.js"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/workers/indexWARC.js
+++ b/workers/indexWARC.js
@@ -41,10 +41,6 @@ export default async (options = {}) => {
   const stream = createReadStream(filename)
 
   for await (const { cdx, record } of indexer.iterIndex([{ reader: stream, filename: basename(filename) }])) {
-    if (!indexer.filterRecord(record)) {
-      continue
-    }
-
     //
     // CDXJ processing
     //

--- a/workers/indexWARC.js
+++ b/workers/indexWARC.js
@@ -41,7 +41,7 @@ export default async (options = {}) => {
   const stream = createReadStream(filename)
 
   for await (const { cdx, record } of indexer.iterIndex([{ reader: stream, filename: basename(filename) }])) {
-    if (!indexer.filterRecord(record) || cdx?.mime === 'application/warc-fields') {
+    if (!indexer.filterRecord(record)) {
       continue
     }
 

--- a/workers/indexWARC.js
+++ b/workers/indexWARC.js
@@ -5,7 +5,7 @@ import fs from 'fs/promises'
 import { basename } from 'path'
 
 import { parse as parseHTML } from 'node-html-parser'
-import { WARCParser, CDXIndexer } from 'warcio'
+import { CDXAndRecordIndexer } from 'warcio'
 import { v4 as uuidv4 } from 'uuid'
 
 /**
@@ -14,12 +14,6 @@ import { v4 as uuidv4 } from 'uuid'
  * - Detect pages (optional)
  *
  * Worker function.
- *
- * [!] Feb 28 2023:
- * This is a temporary and much less efficient implementation of this worker.
- * In order to circumvent a _potential_ bug in WARCParser.iterRecords(),
- * WARCs are iterated over twice at the moment.
- * TBD.
  *
  * @param {Object} options
  * @param {string} options.filename
@@ -30,8 +24,9 @@ import { v4 as uuidv4 } from 'uuid'
 export default async (options = {}) => {
   const filename = options?.filename
   const detectPages = options?.detectPages !== false
-  const cdx = []
-  const pages = []
+
+  /** @type {{cdx: string[], pages: WACZPage[]>} */
+  const output = { cdx: [], pages: [] }
 
   if (!filename) {
     throw new Error('No filename provided.')
@@ -39,49 +34,34 @@ export default async (options = {}) => {
 
   await fs.access(filename) // throws if file does not exist / is not accessible
 
-  // Try to build CDX for current warc
-  cdx.push(...await getCDX(filename))
-
-  // Try to detect pages in record
-  if (detectPages) {
-    pages.push(...await getPages(filename))
-  }
-
-  return { cdx, pages }
-}
-
-/**
- * Iterates over a WARC file and generates CDXJ entries, which will be added to the main `cdx` array.
- * @param {string} filename - Path to .warc or .warc.gz file
- * @returns {Promise<string[]>} - CDXJ entries
- */
-const getCDX = async (filename) => {
-  const cdx = []
+  // For each record:
+  // - Grab CDX and convert to CDXJ
+  // - If page detection is active: parse HTML from record (if text/html response)
+  const indexer = new CDXAndRecordIndexer()
   const stream = createReadStream(filename)
-  const indexer = new CDXIndexer()
 
-  for await (const record of indexer.iterIndex([{ reader: stream, filename: basename(filename) }])) {
-    if (record.mime === 'application/warc-fields') {
+  for await (const { cdx, record } of indexer.iterIndex([{ reader: stream, filename: basename(filename) }])) {
+    if (!indexer.filterRecord(record) || cdx?.mime === 'application/warc-fields') {
       continue
     }
 
-    cdx.push(indexer.serializeCDXJ(record))
-  }
+    //
+    // CDXJ processing
+    //
+    console.log(cdx)
+    const cdxj = indexer.serializeCDXJ(cdx)
 
-  return cdx
-}
+    if (cdxj) {
+      output.cdx.push(cdxj)
+    }
 
-/**
- * Iterates over a WARC file and tries to detect HTML pages, so they can be later added to pages.jsonl.
- * @param {string} filename - Path to .warc or .warc.gz file
- * @returns {Promise<WACZPage[]>}
- */
-const getPages = async (filename) => {
-  const pages = []
-  const stream = createReadStream(filename)
-  const parser = new WARCParser(stream)
+    //
+    // Page detection
+    //
+    if (!detectPages) {
+      continue
+    }
 
-  for await (const record of parser) {
     const warcType = record.warcHeader('WARC-Type')
     const statusCode = record?.httpHeaders?.statusCode
     const contentType = record?.httpHeaders?.headers?.get('content-type')
@@ -106,7 +86,7 @@ const getPages = async (filename) => {
       const html = parseHTML(body)
       const title = html?.querySelector('title')?.textContent
 
-      pages.push({
+      output.pages.push({
         id: uuidv4().replaceAll('-', ''),
         url: targetURI,
         title: title || targetURI,
@@ -115,5 +95,5 @@ const getPages = async (filename) => {
     } catch (_err) { }
   }
 
-  return pages
+  return output
 }

--- a/workers/indexWARC.js
+++ b/workers/indexWARC.js
@@ -48,7 +48,6 @@ export default async (options = {}) => {
     //
     // CDXJ processing
     //
-    console.log(cdx)
     const cdxj = indexer.serializeCDXJ(cdx)
 
     if (cdxj) {


### PR DESCRIPTION
Uses the new `CDXAndRecordIndexer()` construct @ikreymer added to `warcio.js` to solve the problem described in #17 🚀  .

`indexWARC` can now generate a CDXJ entry and run page detection on a given record in the loop cycle. 

---

## Misc
- Moved `cli.js` to `bin/cli.js`
- Minor logging tweaks