### PR TITLE
Missing `profile` property in `datapackage.json`

### DIFF
--- a/index.js
+++ b/index.js
@@ -604,6 +604,7 @@ export class WACZ {
       const datapackage = {
         created: this.datapackageDate,
         wacz_version: '1.1.1',
+        profile: 'data-package',
         software: `${PACKAGE_INFO.name} ${PACKAGE_INFO.version}`,
         resources
       }

--- a/index.test.js
+++ b/index.test.js
@@ -246,6 +246,7 @@ test('WACZ.process runs the entire process and writes a valid .wacz to disk, acc
   const datapackage = JSON.parse(await zip.entryData('datapackage.json'))
 
   assert.equal(datapackage.title, options.title)
+  assert.equal(datapackage.profile, 'data-package')
   assert.equal(datapackage.description, options.description)
   assert.equal(datapackage.mainPageUrl, options.url)
   assert.equal(datapackage.mainPageDate, new Date(options.ts).toISOString())


### PR DESCRIPTION
As per: https://specs.webrecorder.net/wacz/1.1.1/#datapackage-json 